### PR TITLE
Add Moco service / Add CMD capability / Change ENTRYPOINT to EXECFORM from SHELLFORM

### DIFF
--- a/examples/simple-moco-project/.docker-arch.yml
+++ b/examples/simple-moco-project/.docker-arch.yml
@@ -1,0 +1,7 @@
+name: Docker Arch - Simple Moco Project
+services:
+    # Moco Container
+  - type: moco
+    path: ../mocks
+    options:
+        mock_filename: "moco.json"

--- a/examples/simple-moco-project/mocks/moco.json
+++ b/examples/simple-moco-project/mocks/moco.json
@@ -1,0 +1,7 @@
+[
+    {
+        "response": {
+            "text": "Hi, I'm a unicorn, BRO."
+        }
+    }
+]

--- a/src/Application/DockerContainer/MocoDockerContainer.php
+++ b/src/Application/DockerContainer/MocoDockerContainer.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Ph3\DockerArch\Application\DockerContainer;
+
+use Ph3\DockerArch\Domain\DockerContainer\Model\DockerContainer;
+use Ph3\DockerArch\Domain\DockerContainer\Model\DockerContainerInterface;
+
+/**
+ * @author Alexis NIVON <anivon@alexisnivon.fr>
+ */
+class MocoDockerContainer extends DockerContainer
+{
+    const MOCO_INTERNAL_PORT = '8000';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function init(): void
+    {
+        $this->setPackageManager(DockerContainerInterface::PACKAGE_MANAGER_TYPE_APK);
+
+        parent::init();
+
+        $this->setFrom('rezzza/docker-moco');
+        $this->applyWebServiceConfiguration();
+        $this->setMaintainer('Alexis NIVON <anivon@alexisnivon.fr>');
+
+        $mocoServerPort = $this->addEnvPort('MOCO_SERVER', ['from' => '8888', 'to' => self::MOCO_INTERNAL_PORT]);
+        $this->getService()->addUIAccess([
+            'port' => $mocoServerPort['from'],
+            'label' => 'Base URL',
+        ]);
+
+        $this->setEntryPoint('/usr/local/bin/moco');
+
+        $mockFilename = $this->getService()->getOptions()['mock_filename'];
+        $cmd = sprintf(
+            '["start", "-p", "%s", "-c", "%s/%s"]',
+            self::MOCO_INTERNAL_PORT,
+            $this->getWorkingDir(),
+            $mockFilename
+        );
+        $this->setCmd($cmd);
+    }
+}

--- a/src/Application/Resources/views/Base/Service/Dockerfile.twig
+++ b/src/Application/Resources/views/Base/Service/Dockerfile.twig
@@ -64,7 +64,13 @@ RUN {{ command|raw }}
 {% if dockerContainer.entryPoint %}
 
 # Entry point.
-ENTRYPOINT {{ dockerContainer.entryPoint }}
+ENTRYPOINT ["{{ dockerContainer.entryPoint }}"]
+{% endif %}
+{# ----------------------------------------------------- CMD #}
+{% if dockerContainer.cmd %}
+
+# CMD
+CMD {{ dockerContainer.cmd|raw }}
 {% endif %}
 {# ----------------------------------------------------- Done #}
 

--- a/src/Application/Service/MocoService.php
+++ b/src/Application/Service/MocoService.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Ph3\DockerArch\Application\Service;
+
+use Ph3\DockerArch\Domain\Service\Model\AbstractService;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author Alexis NIVON <anivon@alexisnivon.fr>
+ */
+class MocoService extends AbstractService
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getOptionsResolver(): Options
+    {
+        $resolver = new OptionsResolver();
+
+        $resolver->setRequired('mock_filename');
+        $resolver->setAllowedTypes('mock_filename', 'string');
+
+        return $resolver;
+    }
+}

--- a/src/Application/Service/PhpService.php
+++ b/src/Application/Service/PhpService.php
@@ -58,7 +58,7 @@ class PhpService extends AbstractService
      */
     public function allowedLinksExpression(): ?string
     {
-        return '(mysql|mariadb|redis|rabbitmq|elasticsearch)';
+        return '(mysql|mariadb|redis|rabbitmq|elasticsearch|moco)';
     }
 
     /**

--- a/src/Domain/DockerContainer/Model/DockerContainerBasicPropertiesTrait.php
+++ b/src/Domain/DockerContainer/Model/DockerContainerBasicPropertiesTrait.php
@@ -30,6 +30,11 @@ trait DockerContainerBasicPropertiesTrait
     /**
      * @var string
      */
+    protected $cmd;
+
+    /**
+     * @var string
+     */
     protected $user;
 
     /**
@@ -88,6 +93,26 @@ trait DockerContainerBasicPropertiesTrait
     public function setEntryPoint(string $entryPoint): self
     {
         $this->entryPoint = $entryPoint;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCmd(): ?string
+    {
+        return $this->cmd;
+    }
+
+    /**
+     * @param string $cmd
+     *
+     * @return self
+     */
+    public function setCmd(string $cmd): self
+    {
+        $this->cmd = $cmd;
 
         return $this;
     }


### PR DESCRIPTION
- Add Moco Service (with simple example)
- Add CMD capability
   - [Change](https://github.com/Ph3nol/Docker-Arch/pull/7/files#diff-c4801a92f7c0ad99c8ae3ae6e9b40a92R33)
   - [Doc](https://docs.docker.com/engine/reference/builder/#cmd)
- Change ENTRYPOINT to EXECFORM from SHELLFORM
   - [Change](https://github.com/Ph3nol/Docker-Arch/pull/7/files#diff-687b03c0426c2b1a20ba8b9f54b86e3cR67)
   - [Doc](https://docs.docker.com/engine/reference/builder/#entrypoint)