### PR TITLE
Fix complex-php-project example

### DIFF
--- a/examples/complex-php-project/.docker-arch.yml
+++ b/examples/complex-php-project/.docker-arch.yml
@@ -26,7 +26,6 @@ services:
             - "echo $OTHER_TOKEN >> ~/.my-precious-token"
         packages:
             - htop
-            - mtop
         volumes:
             - "../data:/data:rw"
             - "../docker:/docker:ro"


### PR DESCRIPTION
## Error
![image](https://user-images.githubusercontent.com/4992953/30517095-1ac01fd2-9b54-11e7-970b-e415350605ac.png)

## Cause
![image](https://user-images.githubusercontent.com/4992953/30517096-2f05ecc4-9b54-11e7-855d-35813d2b8f01.png)

https://pkgs.alpinelinux.org/packages?name=mtop 

We can remove it now to fix the `complex-php-project` example. 
And then search a cool alternative.